### PR TITLE
Improve: type defs

### DIFF
--- a/Src/Scripts/argparse_helpers.py
+++ b/Src/Scripts/argparse_helpers.py
@@ -35,12 +35,12 @@ import argparse as ap
 import numpy as np
 import regex as re
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, assert_never
+from typing import Any
 from enum import Enum
 
-from Allocator.Interpreter.nptypes import INT_STR_NPMAP, FLOAT_STR_NPMAP
+from Allocator.Interpreter.nptypes import INT_STR_NPMAP, FLOAT_STR_NPMAP, STANDARD_NP_DTYPES
 from Allocator.Interpreter.dataclass import ExtendedEnum, FREQ
 from Allocator.Interpreter.helpers import underline_matches
 
@@ -50,6 +50,9 @@ from Scripts.decorators import warning
 
 
 _, FLOAT32 = FLOAT_STR_NPMAP.FLOAT32.value
+FLOAT = STANDARD_NP_DTYPES.LARGEST_FLOAT.value
+INT = STANDARD_NP_DTYPES.LARGEST_INT.value
+UINT = STANDARD_NP_DTYPES.LARGEST_UINT.value
 
 
 def get_action_from_parser_by_name(parser: ap.ArgumentParser, arg_name: str) -> ap.Action | None:
@@ -66,19 +69,19 @@ def get_action_from_parser_by_name(parser: ap.ArgumentParser, arg_name: str) -> 
                  if action.dest == arg_name), None)
 
 
-def str2int(val: str) -> int:
+def str2int(val: str) -> np.integer:
     if not val.isdigit():
         raise ExpectedIntParseException(f'Couldn\'t parse integer from {val}')
-    return int(val)
+    return INT(val)
 
 
-def str2posint(val: str) -> int:
+def str2posint(val: str) -> np.uint:
     if val.startswith('-'):
         raise ExpectedPosIntParseException(f'Couldn\'t parse positive integer from {val}')
-    return str2int(val)
+    return UINT(str2int(val))
 
 
-def str2negint(val: str) -> int:
+def str2negint(val: str) -> np.integer:
     if not val.startswith('-'):
         raise ExpectedPosIntParseException(f'Couldn\'t parse negative integer from {val}')
     return str2int(val)
@@ -88,7 +91,7 @@ def str2float(val: str) -> np.floating:
     matched = re.fullmatch(r'(\d+(?:\.\d+)?)', val)
     if matched is None:
         raise ExpectedFloatParseException(f'Couldn\'t parse float from {val}')
-    return FLOAT32(matched.group(0))
+    return FLOAT(matched.group(0))
 
 
 def str2posfloat(val: str) -> np.floating:
@@ -103,52 +106,54 @@ def str2negfloat(val: str) -> np.floating:
     return str2float(val)
 
 
-def str2float_with_atmost_n_floating_digits(val: str, n: int) -> np.floating:
+def str2float_with_atmost_n_floating_digits(val: str, n: np.uint) -> np.floating:
     if n == 0:
-        return str2int(val) # if n == 0 return the value as an integer
+        return FLOAT(0)
     if n < 1:
-        raise ValueError('n must be at-least 1 (I.e. match at-least 1 many floating point digits)')
+        raise ValueError('n must be at-least 1 (I.e. match at-least 1 floating point digits)')
 
     matched = re.fullmatch(rf'(\d+(?:\.\d+{{1,{n}}})?)', val)
     if matched is None:
         raise ExpectedFloatParseException(f'Expected a float with at-least n ({n}) many decimal point places but got {val}')
-    return FLOAT32(matched.group(0))
+    return FLOAT(matched.group(0))
 
 
-def str2num(val: str) -> np.floating | int:
+def str2num(val: str) -> np.floating | np.integer:
     if val.find('.'):
         return str2float(val)
     return str2int(val)
 
 
-def str2posnum(val: str) -> np.floating | int:
+def str2posnum(val: str) -> np.floating | np.integer:
     if val.find('.'):
         return str2posfloat(val)
     return str2posint(val)
 
 
-def str2negnum(val: str) -> np.floating | int:
+def str2negnum(val: str) -> np.floating | np.integer:
     if val.find('.'):
         return str2negfloat(val)
     return str2negint(val)
 
 
-def num_in_range(val: np.floating | int, r: range,
+def num_in_range(val: np.floating | np.integer, r: range,
                 lower_inclusive: bool = True,
-                upper_inclusive: bool = True) -> np.floating | int:
+                upper_inclusive: bool = True) -> np.floating | np.integer:
+
     if (lower_inclusive and val < r.start) or (upper_inclusive and val > r.stop) or\
         (not lower_inclusive and val <= r.start) or (not lower_inclusive and val >= r.stop):
         lower_symb = '[' if lower_inclusive else '('
         upper_symb = ']' if upper_inclusive else ')'
-        if isinstance(val, FLOAT32):
+        if isinstance(val, np.floating):
             raise ap.ArgumentTypeError(f'Expected a float in the range: {lower_symb}{r.start}, {r.stop}{upper_symb}'
                                         f' but got {val}'
                                         )
-        if isinstance(val, int):
+        if isinstance(val, np.integer):
             raise ap.ArgumentTypeError(f'Expected an integer in the range: {lower_symb}{r.start}, {r.stop}{upper_symb}'
                             f' but got {val}'
                             )
-        assert_never(f'Value should be an integer or float but got {val} instead')
+        raise ValueError(f'Value should be an integer or float but got {val} instead')
+
     return val
 
 
@@ -323,8 +328,8 @@ def str2path(val: str) -> Path:
 
 
 def str2path_belongs_in(val: str, ancestor: Path, enforce_exists: bool = True) -> Path:
-    fp: Path = Path(val)
-    if not fp.is_absolute():
+    fp = str2path(val)
+    if not val.is_absolute():
         fp = str2relpath(val, root=ancestor, enforce_exists=enforce_exists)
     try:
         fp.relative_to(ancestor)
@@ -333,8 +338,7 @@ def str2path_belongs_in(val: str, ancestor: Path, enforce_exists: bool = True) -
     return fp
 
 
-def str2relpath(val: str, root: str = SRC_DIR, enforce_exists: bool = True,
-                excluded: set = {'.git', '__pycache__', '.venv', 'node_modules', 'obj_dir', '.cache'}) -> Path:
+def str2relpath(val: str, root: str = SRC_DIR, enforce_exists: bool = True) -> Path:
     # Try direct join from Src if it exists
     project_root = META_INFO.GIT_ROOT
     search_root = project_root / root # Default search root is Src directory
@@ -349,8 +353,9 @@ def str2relpath(val: str, root: str = SRC_DIR, enforce_exists: bool = True,
     filename = Path(val).name
     matches = []
     for match in search_root.rglob(filename):
+
         # Skip if any parent directory is in excluded set
-        if not any(parent.name in excluded for parent in match.parents):
+        if not any(parent.name in META_INFO.EXCLUDED_DIRS for parent in match.parents):
             matches.append(match)
 
     if not matches:
@@ -361,12 +366,11 @@ def str2relpath(val: str, root: str = SRC_DIR, enforce_exists: bool = True,
     return shallowest_match
 
 
-def str2freq(val: str, granularity: FREQ = FREQ.KHZ) -> int:
+def str2freq(val: str, granularity: FREQ = FREQ.KHZ) -> np.uint:
     try:
-        n_accepted_digits = int(np.log10(granularity.value))
+        n_accepted_digits = UINT(np.log10(granularity.value))
         val = str2float_with_atmost_n_floating_digits(val, n_accepted_digits)
     except ExpectedFloatParseException:
-        # n_accepted_digits >= 1 as if n_accepted_digits = 0, behaviour is to cast to integer
         err_regex = rf'\d*\.(\d{{0,{n_accepted_digits}}})'
         err_msg = f'{underline_matches(val, err_regex, literal=False)} instead'
         raise ap.ArgumentTypeError('Given value couldn\'t be parsed as an appropriate frequency value.'
@@ -374,42 +378,42 @@ def str2freq(val: str, granularity: FREQ = FREQ.KHZ) -> int:
                                    f' {n_accepted_digits} floating point digit places. But got:'
                                    f' {err_msg}'
                                    )
-    return int(val * granularity.value)
+    return UINT(val * granularity.value)
 
 
-def str2bitwidth(v: str, is_int: bool = False) -> tuple[int, np.floating]:
+def str2bitwidth(val: str, is_int: bool = False) -> Sequence[np.uint, np.floating]:
     type_mapping = FLOAT_STR_NPMAP if not is_int else INT_STR_NPMAP
-    if isinstance(v, str):
-        if v.isdigit():
-            # If arg is purely digits attempt to convert to positive integer
-            v = str2posint(v)
-        else:
-            # If the arg is a mix of char & digits
-            v = v.upper()
-            if v not in type_mapping:
-                raise ap.ArgumentTypeError('If value is specified by type alias it must be one'
-                                           f' of {type_mapping.fields()} but got {v} instead'
-                                          )
-            return type_mapping.get_member_via_name(v).value
+    if val.isdigit():
+        # If arg is purely digits attempt to convert to positive integer
+        val = str2posint(val)
+    else:
+        # If the arg is a mix of char & digits
+        val = val.upper()
+        if val not in type_mapping:
+            raise ap.ArgumentTypeError('If value is specified by type alias it must be one'
+                                        f' of {type_mapping.fields()} but got {val} instead'
+                                        )
+        return type_mapping.get_member_via_name(val).value
 
-    v: int
-    if v < 16 or v > 128:
+    if val < 16 or val > 128:
         valid_floatw = ' '.join(type_mapping.fields())
         raise ap.ArgumentTypeError('Value must be positive int in range [16, 128]'
-                                   f' but got {v} instead. I.e.:'
+                                   f' but got {val} instead. I.e.:'
                                    f'\n{underline_matches(valid_floatw, lambda char: char.isdigit())}'
                                    )
-    if v not in type_mapping:
+
+    if val not in type_mapping:
         raise ap.ArgumentTypeError('If value is specified as a digit it must be one'
-                                    f' of {[v for v in type_mapping.values() if isinstance(v, int)]} but got {v} instead'
+                                    f' of {[v for v in type_mapping.values()]} but got {val} instead'
                                     )
-    return type_mapping.get_member_via_value(v).value
+
+    return type_mapping.get_member_via_value(val).value
 
 
 def get_non_flags(parser: ap.ArgumentParser) -> Mapping[str, Any]:
     non_flags = [action.option_strings for action in parser._actions]
     non_flags = [opt.removeprefix('-').replace('-', '_') for opt in
                  itertools.chain.from_iterable(non_flags)
-                 if not opt.startswith('--')]   # Excl. non flags
-    non_flags.extend([action.dest for action in parser._get_positional_actions()]) # Excl. positionals
+                 if not opt.startswith('--')]                                       # Excl. non flags
+    non_flags.extend([action.dest for action in parser._get_positional_actions()])  # Excl. positionals
     return non_flags

--- a/Src/Scripts/consts.py
+++ b/Src/Scripts/consts.py
@@ -65,7 +65,8 @@ META_INFO = ProgramMetaInformation(
     **{
         'DATE_RUN': dt.datetime.now(),
         'GIT_ROOT': get_repo_root(),
-        'AUTHOR_CREDENTIALS': get_git_author()
+        'AUTHOR_CREDENTIALS': get_git_author(),
+        'EXCLUDED_DIRS': {'.git', '__pycache__', '.venv', 'node_modules', 'obj_dir', '.cache'}
     }
 )
 

--- a/Src/Scripts/dataclass.py
+++ b/Src/Scripts/dataclass.py
@@ -47,6 +47,7 @@ class ProgramMetaInformation:
     DATE_RUN: dt.datetime
     GIT_ROOT: Path
     AUTHOR_CREDENTIALS: Sequence[str, str]
+    EXCLUDED_DIRS: set
 
 
 @dataclass(frozen=True)

--- a/Src/Scripts/generate_trig_luts.py
+++ b/Src/Scripts/generate_trig_luts.py
@@ -252,48 +252,46 @@ class _TrigArgParser():
         self.bw_sz, self.args['bw'] = self.args['bw']
 
         self.bw_sz_bytes = self.bw_sz // 8
-        self.n_entries = self.args['bram'] // self.bw_sz_bytes                                  # Num. of entries in table / lut
+        self.n_entries = self.args['bram'] // self.bw_sz_bytes                        # Num. of entries in table / lut
         self.bw_type_int = INT_STR_NPMAP.get_member_via_value(self.bw_sz).value[1]    # Integer equiv. of bw_sz
 
         self.trig_opts = None
 
     @staticmethod
-    def bram(v: str) -> int:
-        return int(eval_arithmetic_str_safe(v))
+    def bram(val: str) -> np.uint:
+        return np.uint64(eval_arithmetic_str_safe(val))
 
     @staticmethod
-    def precmode(v: str) -> ExtendedEnum:
-        if v in TRIG_DEFS:
-            return str2enumval(v, TRIG_DEFS)
-        return str2enumval(v, TRIG_PRECISION)
+    def precmode(val: str) -> ExtendedEnum:
+        if val in TRIG_DEFS:
+            return str2enumval(val, TRIG_DEFS)
+        return str2enumval(val, TRIG_PRECISION)
 
     @staticmethod
-    def kthresh(v: str) -> np.floating:
-        if isinstance(v, str):
-            if v.isdigit():
-                v = str2float(v)
-            else:
-                v = eval_arithmetic_str_safe(v)
+    def kthresh(val: str) -> np.floating:
+        if val.isdigit():
+            val = str2float(val)
+        else:
+            val = eval_arithmetic_str_safe(val)
 
-        if v >= 1 or v <= 0:
+        if val >= 1 or val <= 0:
             raise ap.ArgumentTypeError('Value must be positive float in range (0, 1)'
-                                       f' but got {v:.6f} instead'
+                                       f' but got {val:.6f} instead'
                                        )
-        return v
+        return val
 
     @staticmethod
-    def os_factor(v: str) -> int:
-        if isinstance(v, str):
-            if v.isdigit():
-                v = str2posint(v)
-            else:
-                v = int(eval_arithmetic_str_safe(v))
+    def os_factor(val: str) -> np.uint:
+        if val.isdigit():
+            val = str2posint(val)
+        else:
+            val = np.uint(eval_arithmetic_str_safe(val))
 
-        if not float(np.log2(v)).is_integer():
+        if not float(np.log2(val)).is_integer():
             raise ap.ArgumentTypeError('Value must be a power of 2'
-                                       f' but got {v} instead'
+                                       f' but got {val} instead'
                                        )
-        return v
+        return val
 
     def _check_bram_sz(self) -> bool:
         """
@@ -577,7 +575,7 @@ def tan_k_N_pi4(k: np.floating) -> np.floating:
     return np.ceil(np.pi / (2 * k) + 1)
 
 
-def newton_raphson_atan_N(k: np.integer, tolerance: float = 1e-7, max_iter: int = 100) -> np.floating | None:
+def newton_raphson_atan_N(k: np.floating, k_tolerance: np.floating = 1e-7, max_iter: np.uint = 100) -> np.floating | None:
     """
     atan(x) may be written as 0.5*i*ln(1 - i*x) - 0.5*i*ln(1 + i*x)
     => Indefinite integral of atan(x) from 0 to N for some natural number N is:
@@ -603,7 +601,7 @@ def newton_raphson_atan_N(k: np.integer, tolerance: float = 1e-7, max_iter: int 
         denominator_f_prime = N_current**2 + 1
         f_prime_N = (2 * N_current / denominator_f_prime) - 2 * k
 
-        if abs(f_prime_N) < tolerance: # Avoid division by a very small number (or zero)
+        if abs(f_prime_N) < k_tolerance: # Avoid division by a very small number (or zero)
             break
 
         # Newton-Raphson iteration
@@ -613,7 +611,7 @@ def newton_raphson_atan_N(k: np.integer, tolerance: float = 1e-7, max_iter: int 
             break
 
         # Check for convergence
-        if abs(N_next - N_current) < tolerance:
+        if abs(N_next - N_current) < k_tolerance:
             return N_next
 
         # Update N for the next iteration
@@ -622,7 +620,7 @@ def newton_raphson_atan_N(k: np.integer, tolerance: float = 1e-7, max_iter: int 
     return
 
 
-def sinc_k_N(x: np.ndarray[np.floating], epsilon: np.floating, max_iter: int = 100) -> np.floating:
+def sinc_k_N(x: np.ndarray[np.floating], epsilon: np.floating, max_iter: np.uint = 100) -> np.floating:
     """# Summary
 
     Find minimum N such that |cos(x) - cos_N(x)| < epsilon.
@@ -1090,10 +1088,10 @@ def _get_fn_from_optmode(m: TRIG_DEFS, trig_parser: _TrigArgParser) -> Callable[
     return TRIG_FN_DEFS.get_member_via_name(m.name).value[1]
 
 
-def assess_lut_accuracy(fn: Callable[..., float],
-                         lut: Sequence[float], axis: Sequence[float],
-                         oversample_factor: int, type: float,
-                         test_type: float = np.float32) -> LUT_ACC_REPORT | None:
+def assess_lut_accuracy(fn: Callable[..., np.floating],
+                         lut: Sequence[np.floating], axis: Sequence[np.floating],
+                         oversample_factor: np.uint, type: np.floating,
+                         test_type: np.dtype = np.float32) -> LUT_ACC_REPORT | None:
     """ # Summary
 
     Assesses the lut accuracy against a function, fn, sampled at oversample_factor


### PR DESCRIPTION
- Prefer np.floating, np.integer, np.uint wherever possible
- Cast to largest avaliable system sizes for the above respective types in str2<type> functions
- Change to use `val` as parameter name for argparse methods
- Various type annotation corrections
- Change assert_never to ValueError
- feed val to str2path first in str2path_belongs_in
- rename `tolerance` to `k_tolerance` to be more explicit