### PR TITLE
WIP Refactor, Feat: Inverse Trig LUT Domains, Reconstruction Logic, E…

### DIFF
--- a/Src/Allocator/Interpreter/dataclass.py
+++ b/Src/Allocator/Interpreter/dataclass.py
@@ -297,13 +297,15 @@ class SIGNAL_TYPE(Enum):
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class SIGNAL_METRIC:
-    signal: np.ndarray[np.floating | np.integer]
+    signal: np.ndarray[np.float64 | np.integer]
     signal_type: SIGNAL_TYPE
     signal_name: str | None
 
 
 class SignalStatistic(metaclass=SingletonMetaSubclass):
-    __slots__ = ('_signal_metric', '_signal', '_signal_type', '_signal_name', '_signal_mean', '_is_periodic', '_unbiased_signal')
+
+    __slots__ = ('_signal_metric', '_signal', '_signal_type', '_signal_norm',
+    '_signal_name', '_signal_mean', '_is_periodic', '_unbiased_signal', '_unbiased_signal_norm')
 
     def __init__(self, signal: np.ndarray[np.number], signal_type: SIGNAL_TYPE, signal_name: str | None = None):
         self._signal = signal
@@ -313,8 +315,22 @@ class SignalStatistic(metaclass=SingletonMetaSubclass):
         # Defer to property time creation, I.e. lazy load
         self._signal_metric = None
         self._signal_mean = None
+        self._signal_norm = None
         self._is_periodic = None
         self._unbiased_signal = None
+        self._unbiased_signal_norm = None
+
+    @property
+    def signal(self):
+        return self._signal
+
+    @property
+    def signal_name(self):
+        return self._signal_name
+
+    @property
+    def signal_type(self):
+        return self._signal_type
 
     @property
     def signal_metric(self):
@@ -333,6 +349,12 @@ class SignalStatistic(metaclass=SingletonMetaSubclass):
         return self._signal_mean
 
     @property
+    def signal_norm(self):
+        if self._signal_norm is None:
+            self._signal_norm =  np.sum(self.signal**2) if self.signal.size > 0 else 1.0
+        return self._signal_norm
+
+    @property
     def is_periodic(self):
         if self._is_periodic is None:
             self._is_periodic = self.signal_metric.signal_type == SIGNAL_TYPE.TRIG and self.signal_metric.signal_name in ('sin', 'cos', 'tan')
@@ -343,6 +365,13 @@ class SignalStatistic(metaclass=SingletonMetaSubclass):
         if self._unbiased_signal is None:
             self._unbiased_signal = self.signal_metric.signal - self.signal_mean
         return self._unbiased_signal
+
+    @property
+    def unbiased_signal_norm(self):
+        if self._unbiased_signal_norm is None:
+            us = self.unbiased_signal
+            self._unbiased_signal_norm = np.sum(us**2) if us.size > 0 else 1.0
+        return self._unbiased_signal_norm
 
 
 class TABLE_MODE(ExtendedEnum):
@@ -382,13 +411,13 @@ class QFormat:
         self._fxp_parser = functools.partial(Fxp, signed=self.signed, n_word=self.integer_part_bw + self.floating_part_bw,
                                  n_frac=self.floating_part_bw)
 
-    def get_converted(self, val: np.ndarray[np.floating] | np.floating) -> np.uint:
+    def get_converted(self, val: np.ndarray[np.float64] | np.float64) -> np.uint:
         uint_alias: np.unsignedinteger
         sz = val[0].itemsize * 8 if isinstance(val, np.ndarray) else val.itemsize * 8
         _, uint_alias = INT_STR_NPMAP.get_member_via_name(f'UINT{sz}').value
         return uint_alias(self._fxp_parser(val).val)
 
-    def get_float_representation(self, val: np.ndarray[np.uint] | np.uint) -> np.floating:
+    def get_float_representation(self, val: np.ndarray[np.uint] | np.uint) -> np.float64:
         return val / 2 ** self.floating_part_bw
 
 
@@ -403,7 +432,7 @@ class LUT_QUANT_ACC_REPORT:
     min_acc: np.float32
     max_acc: np.float32
     std:     np.float32
-    acc_scores: np.ndarray[np.floating]
+    acc_scores: np.ndarray[np.float64]
 
     def __str__(self):
         return (f'---LUT QUANTIZATION ERROR ACC REPORT---'
@@ -422,12 +451,32 @@ class LUT_THD_ACC_REPORT:
     """
     thd_dB: np.float32
     thd_scalar: np.float32
+    test_type: str = 'THD'
 
     def __str__(self):
-        return (f'---LUT THD ACC REPORT---'
-          f'\n\n\tTHD dB: {self.thd_dB:0.5f}'
-          f'\n\tTHD (%) {self.thd_scalar:.2%}'
-          f'\n\tTHD scalar: {self.thd_scalar:0.5f}')
+        header = f'---LUT {self.test_type} ACC REPORT---'
+        if self.test_type == 'THD':
+            body = (f'\n\n\tTHD dB: {self.thd_dB:0.5f}'
+                    f'\n\tTHD (%) {self.thd_scalar:.2%}'
+                    f'\n\tTHD scalar: {self.thd_scalar:0.5f}')
+        elif self.test_type == 'K_CUT_DIST':
+            body = (f'\n\n\tK-cut distortion dB: {self.thd_dB:0.5f}'
+                    f'\n\tK-cut (%): {self.thd_scalar:.2%}'
+                    f'\n\tK-cut distortion scalar: {self.thd_scalar:0.5f}')
+
+        elif self.test_type == 'CHEB_MODEL':
+            body = (f'\n\n\tChebyshev residual/model dB: {self.thd_dB:0.5f}'
+                    f'\n\tChebyshev (%): {self.thd_scalar:.2%}'
+                    f'\n\tChebyshev residual/model scalar: {self.thd_scalar:0.5f}')
+        elif self.test_type == 'RESIDUAL_RMS':
+            body = (f'\n\n\tResidual RMS ratio dB: {self.thd_dB:0.5f}'
+                    f'\n\tResidual RMS ratio (%): {self.thd_scalar:.2%}'
+                    f'\n\tResidual RMS ratio scalar: {self.thd_scalar:0.5f}')
+        else:
+            body = (f'\n\n\tMetric dB: {self.thd_dB:0.5f}'
+                    f'\n\tMetric (%): {self.thd_scalar:.2%}'
+                    f'\n\tMetric scalar: {self.thd_scalar:0.5f}')
+        return header + body
 
 
 @dataclass
@@ -460,18 +509,18 @@ class LUT:
 
     Dataclass used for an arbitrary generated LUT
     """
-    table: np.ndarray[np.integer | np.floating]
-    domain: np.ndarray[np.integer | np.floating]
-    domain_fn: Callable[..., np.ndarray[np.integer | np.floating]]
+    table: np.ndarray[np.integer | np.float64]
+    domain: np.ndarray[np.integer | np.float64]
+    domain_fn: Callable[..., np.ndarray[np.integer | np.float64]]
     type: LUT_TYPE
     q_format: QFormat
     endianness: BYTEORDER
     bit_width: np.uint
     table_sz: np.uint
     lop: ExtendedEnum
-    scale_factor: np.floating
+    scale_factor: np.float64
     table_mode: ExtendedEnum
-    fn: Callable[..., np.floating]
+    fn: Callable[..., np.float64]
     cmd: str | None # Command used to create LUT
 
     _acc_report: LUT_QUANT_ACC_REPORT | None = None

--- a/Src/Allocator/Interpreter/signal_metrics.py
+++ b/Src/Allocator/Interpreter/signal_metrics.py
@@ -25,6 +25,7 @@ Otherwise please consult: https://github.com/topologicalhurt/Thesis/blob/main/LI
 
 import numpy as np
 import scipy as sp
+import functools
 
 from collections.abc import Callable
 from typing import override
@@ -33,11 +34,8 @@ from Allocator.Interpreter.dataclass import LUT_QUANT_ACC_REPORT, LUT_THD_ACC_RE
 
 
 # TODO:
-# (1): support more than just sin & cos reconstruction
-# (2): make function using autocorr to check for periodicity
+# (1): make function using autocorr to check for periodicity
 #       - if function is known / elementary, then just use conditional check
-# (3): support options to remove up to nth harmonic of the fundamental freq. or just the fundamental freq
-# (4): refactor potentially reusable signal methods into `signals.py`
 
 
 class PeriodicityMetrics(SignalStatistic):
@@ -55,22 +53,37 @@ class PeriodicityMetrics(SignalStatistic):
         """Use normalized autocorrelation to determine periodicity.
         Return the period of the function if it is periodic, with a result of 0 indicating no periodicity.
         """
-        sig_norm = np.sum(self.unbiased_signal**2)
 
         # Per the np.correlate documentation, FFT isn't use to compute the convolution which is inefficient on large arrays
         # sp.signal.correlate DOES do this, however.
-        if self.signal.size >= 1e5:
-            autocorr = sp.signal.correlate(self._unbiased_signal, self._unbiased_signal, mode='same') / sig_norm # noqa: F841
-        else:
-            autocorr = np.correlate(self._unbiased_signal, self._unbiased_signal, mode='same') / sig_norm        # noqa: F841
+        # if self.signal.size >= 1e5:
+        #     autocorr = sp.signal.correlate(self._unbiased_signal, self._unbiased_signal, mode='same') / self.unbiased_signal_norm
+        # else:
+        #     autocorr = np.correlate(self._unbiased_signal, self._unbiased_signal, mode='same') / self.unbiased_signal_norm
 
-        return 0 # BUG: TEMP
+        return np.uint(0) # BUG: TEMP
 
 
 class DistortionMetrics(SignalStatistic):
 
     def __init__(self, signal: np.ndarray[np.number], signal_type: SIGNAL_TYPE, signal_name: str | None = None):
         super().__init__(signal=signal, signal_type=signal_type, signal_name=signal_name)
+
+    @staticmethod
+    def band_power(spec, center_bin: np.float64, half_width: np.uint) -> np.float64:
+        """Sum power around a fractional bin center over ±half_width bins."""
+        c = np.uint(np.round(center_bin))
+        mag = np.abs(spec)
+        lo = np.max(0, c - half_width)
+        hi = np.min(mag.size - 1, c + half_width)
+        return np.float64(np.sum(mag[lo:hi + 1] ** 2))
+
+    @staticmethod
+    def _dist_scalar_db(p_signal: np.float64, p_dist: np.float64) -> tuple[np.float64, np.float64]:
+        if p_signal <= 0 or p_dist <= 0:
+            return np.float64(0.0), np.float64(-np.inf)
+        d = np.sqrt(p_dist / p_signal)
+        return np.float64(d), np.float64(20.0 * np.log10(max(d, np.finfo(np.float64).tiny)))
 
     def assess_thd(self, window_type: SIG_WINDOW_TYPE = SIG_WINDOW_TYPE.FLATTOP) -> LUT_THD_ACC_REPORT | None:
         """Assess THD.
@@ -87,68 +100,194 @@ class DistortionMetrics(SignalStatistic):
         x = np.asarray(self.unbiased_signal, dtype=np.float64).copy()
         n = x.size
         if n < 4:
-            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
         if self.is_periodic:
             # Periodic path: FFT with integer-bin harmonics
             spec = np.fft.rfft(x)
             mag = np.abs(spec)
             if mag.size <= 1:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
             k1 = np.argmax(mag[1:]) + 1  # strongest bin after DC
             # Use exact-bin power for periodic signals to avoid band overlap issues
             p_fund = np.float64(mag[k1] ** 2)
             if p_fund <= 0.0:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
             max_h = (mag.size - 1) // k1
             if max_h < 2:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
             harm_idx = np.arange(2, max_h + 1) * k1
-            p_harm = np.float64(np.sum(mag[harm_idx] ** 2)) if harm_idx.size else 0.0
+            p_harm = np.float64(np.sum(mag[harm_idx] ** 2)) if harm_idx.size else np.float64(0.0)
         else:
-            """Non-periodic path: DCT-II analysis on finite interval.
-            Optional: apply a gentle taper to mitigate endpoint slope (reduces Gibbs).
-            Keep it mild to not depress the "fundamental" excessively."""
-            w = window_type(n)
-            xw = x * w
+            # Non-periodic: DCT-II. For inverse trig (monotonic) remove low-order trend first.
+            x_proc = x
+            if self.signal_name in ('asin', 'acos'):
+                t = np.linspace(-1.0, 1.0, n, dtype=x.dtype)
 
-            # DCT-II via even extension + FFT (normalization cancels in ratio)
-            y = np.concatenate([xw, xw[::-1]])
-            Y = np.fft.rfft(y)
-            N = n
-            phase = np.exp(-1j * np.pi * np.arange(N) / (2 * N))
-            c = (Y[:N] * phase).real  # DCT-II-like coefficients up to a constant factor
+                # cubic captures bulk smooth curvature; residual holds higher "ripples"
+                coeff = np.polyfit(t, x, 3)
+                trend = np.polyval(coeff, t)
+                x_proc = x - trend
 
-            # Ignore DC (k=0); pick strongest cosine term as "fundamental" for THD baseline
-            if N <= 1:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+                if np.allclose(x_proc, 0.0):
+                    return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
+            c = sp.fft.dct(x_proc, type=2, norm='ortho')
             mags = np.abs(c)
-            if mags[1:].size == 0:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+
+            if mags.size <= 2 or not np.any(mags[1:]):
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
             k_fund = np.argmax(mags[1:]) + 1
-            p_fund = (mags[k_fund] ** 2)
-            if p_fund <= 0.0:
-                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=0.0)
+            p_fund = np.float64(mags[k_fund] ** 2)
 
-            # Sum all higher-order cosine terms as "harmonics"
-            mask = np.ones_like(mags, dtype=bool)
-            mask[0] = False         # drop DC
-            mask[k_fund] = False    # drop fundamental
-            p_harm = np.float64(np.sum(mags[mask] ** 2))
+            if p_fund <= 0:
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='THD')
 
-        thd = np.sqrt(p_harm / p_fund) if p_harm > 0.0 else 0.0
-        thd_db = 20.0 * np.log10(max(thd, np.finfo(float).tiny)) if thd > 0.0 else -np.inf
-        return LUT_THD_ACC_REPORT(thd_dB=thd_db, thd_scalar=np.float64(thd))
+            harm_mask = np.ones_like(mags, dtype=bool)
+            harm_mask[0] = False
+            harm_mask[k_fund] = False
+            p_harm = np.float64(np.sum(mags[harm_mask] ** 2))
 
+        thd, thd_db = self._dist_scalar_db(p_fund, p_harm)
+        return LUT_THD_ACC_REPORT(thd_dB=thd_db, thd_scalar=np.float64(thd), test_type='THD')
+
+    def _poly_detrend(self, x: np.ndarray, order: int | None) -> np.ndarray:
+        """Polynomial detrend.
+
+        Removes a low-order polynomial (Legendre-like on normalized grid) capturing smooth trend.
+        Use to isolate higher-frequency residual before spectral metrics.
+
+        Params:
+            x: signal
+            order: polynomial degree or None to skip
+        Returns:
+            residual = x - poly_fit(x)
+        """
+        if order is None:
+            return x
+
+        n = x.size
+        t = np.linspace(-1.0, 1.0, n, dtype=x.dtype)
+        order = min(order, n-1)
+        c = np.polyfit(t, x, order)
+        return x - np.polyval(c, t)
+
+    def dct_kcut_distortion(self, k_cut: int, detrend_order: int | None = None) -> LUT_THD_ACC_REPORT | None:
+        """K-cut distortion metric.
+
+        Defines modeled content as first k_cut non-DC spectral bins (FFT for periodic, DCT-II for finite non-periodic).
+        Distortion = sqrt(energy outside band / energy inside band). Optional polynomial detrend improves focus on ripples for monotonic inverse trig.
+
+        Params:
+            k_cut: number of lowest non-DC bins treated as modeled
+            detrend_order: polynomial order for non-periodic detrend (None disables)
+        Returns:
+            LUT_THD_ACC_REPORT with dB and scalar of distortion ratio
+        """
+        x = np.asarray(self.unbiased_signal, dtype=np.float64)
+        n = x.size
+
+        if n < 4 or k_cut < 1:
+            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='K_CUT_DIST')
+
+        if self.is_periodic:
+            spec = np.fft.rfft(x)
+            mag = np.abs(spec)
+
+            if mag.size <= k_cut:
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='K_CUT_DIST')
+
+            p_total = np.sum(mag[1:]**2)
+            p_main = np.sum(mag[1:k_cut+1]**2)
+        else:
+            xr = self._poly_detrend(x, detrend_order)
+            c = sp.fft.dct(xr, type=2, norm='ortho')
+            mags = np.abs(c)
+
+            if mags.size <= k_cut:
+                return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='K_CUT_DIST')
+
+            p_total = np.sum(mags[1:]**2)
+            p_main = np.sum(mags[1:k_cut+1]**2)
+
+        if p_total <= 0 or p_main <= 0:
+            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='K_CUT_DIST')
+
+        p_harm = p_total - p_main
+        d, d_db = self._dist_scalar_db(p_main, p_harm)
+        return LUT_THD_ACC_REPORT(thd_dB=d_db, thd_scalar=np.float64(d), test_type='K_CUT_DIST')
+
+    def residual_rms_ratio(self, detrend_order: int = 3) -> np.float64:
+        """Residual RMS ratio.
+
+        After polynomial detrend (default cubic) computes RMS(residual)/RMS(original).
+        Simple scale-invariant measure of remaining high-order structure; near 0 => almost entirely smooth trend.
+
+        Params:
+            detrend_order: polynomial order for removal
+        Returns:
+            scalar in [0,1] (can exceed slightly with numeric noise)
+        """
+        x = np.asarray(self.unbiased_signal, dtype=np.float64)
+
+        if x.size < detrend_order+2:
+            return np.float64(0.0)
+
+        r = self._poly_detrend(x, detrend_order)
+        num = np.sqrt(np.mean(r**2))
+        den = np.sqrt(np.mean(x**2))
+        return np.float64(num/den) if den>0 else np.float64(0.0)
+
+    def _cheb_detrend(self, x: np.ndarray, n_terms: int) -> tuple[np.ndarray, np.ndarray]:
+        """Chebyshev detrend returning residual and coeffs (first n_terms)."""
+        n = x.size
+        if n < 2 or n_terms < 1:
+            return x, np.zeros(1, dtype=x.dtype)
+        t = np.linspace(-1.0, 1.0, n, dtype=x.dtype)
+        deg = min(n_terms - 1, n - 1)
+        coeffs = np.polynomial.chebyshev.chebfit(t, x, deg)
+        model = np.polynomial.chebyshev.chebval(t, coeffs)
+        return x - model, coeffs
+
+    def cheb_model_distortion(self, n_terms: int = 8) -> LUT_THD_ACC_REPORT | None:
+        """Chebyshev model distortion.
+
+        Fits first n_terms Chebyshev polynomials (even-optimized basis for [-1,1]).
+        Distortion = sqrt(E_residual / E_model) where model is truncated Chebyshev series.
+        Useful for monotonic inverse trig where low-order Chebyshev captures bulk curvature.
+
+        Params:
+            n_terms: number of Chebyshev terms in model
+        Returns:
+            LUT_THD_ACC_REPORT with distortion scalar/dB
+        """
+        x = np.asarray(self.unbiased_signal, dtype=np.float64)
+
+        if x.size < 4 or n_terms < 1:
+            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='CHEB_MODEL')
+
+        residual, _ = self._cheb_detrend(x, n_terms)
+        model_energy = np.sum((x - residual)**2)
+
+        if model_energy <= 0:
+            return LUT_THD_ACC_REPORT(thd_dB=-np.inf, thd_scalar=np.float64(0.0), test_type='CHEB_MODEL')
+
+        res_energy = np.sum(residual**2)
+        d, d_db = self._dist_scalar_db(model_energy, res_energy)
+        return LUT_THD_ACC_REPORT(thd_dB=d_db, thd_scalar=np.float64(d), test_type='CHEB_MODEL')
+
+    def residual_rms_report(self, detrend_order: int = 3) -> LUT_THD_ACC_REPORT:
+        r = self.residual_rms_ratio(detrend_order)
+        _, d_db = self._dist_scalar_db(1.0, r)
+        return LUT_THD_ACC_REPORT(thd_dB=d_db, thd_scalar=np.float64(r), test_type='RESIDUAL_RMS')
 
     def assess_quantization_error(self,
-                        fn: Callable[..., np.floating],
-                        axis: np.ndarray[np.floating],
+                        fn: Callable[..., np.float64],
+                        axis: np.ndarray[np.float64],
                         oversample_factor: np.uint,
                         q_format: QFormat | None = None,
                         dtype: np.dtype | None = None) -> LUT_QUANT_ACC_REPORT | None:
@@ -186,11 +325,14 @@ class DistortionMetrics(SignalStatistic):
 
         return acc_report
 
-
-def band_power(spec, center_bin: np.floating, half_width: np.uint) -> np.float64:
-    """Sum power around a fractional bin center over ±half_width bins."""
-    c = np.uint(np.round(center_bin))
-    mag = np.abs(spec)
-    lo = np.max(0, c - half_width)
-    hi = np.min(mag.size - 1, c + half_width)
-    return np.float64(np.sum(mag[lo:hi + 1] ** 2))
+    def select_distortion_metric(self, execute: bool = True):
+        name = (self.signal_name or '').lower()
+        trig = ('sin','cos','tan')
+        inv_trig = ('arcsin','arccos','arctan')
+        if name in trig:
+            fn = self.assess_thd
+        elif name in inv_trig:
+            fn = functools.partial(self.cheb_model_distortion, n_terms=16)
+        else:
+            fn = self.assess_thd if self.signal_type == SIGNAL_TYPE.TRIG else functools.partial(self.cheb_model_distortion, n_terms=16)
+        return fn() if execute else fn

--- a/Src/Allocator/Interpreter/signal_reconstructor.py
+++ b/Src/Allocator/Interpreter/signal_reconstructor.py
@@ -25,6 +25,7 @@ Otherwise please consult: https://github.com/topologicalhurt/Thesis/blob/main/LI
 
 import numpy as np
 
+# from Allocator.Interpreter.helpers import find_nearest
 from Allocator.Interpreter.dataclass import TABLE_MODE
 
 
@@ -63,52 +64,93 @@ def reconstruct_arcsin_qwave(qwave: np.ndarray[np.number]) -> np.ndarray[np.numb
     return np.sign(x) * 2.0 * arcsin_half
 
 
+def reconstruct_arccos_hwave(hwave: np.ndarray[np.number]) -> np.ndarray[np.number] | np.number:
+    """Reconstruct arccos(x) for x∈[-1,1] from a *half-wave* LUT.
+
+    Assumptions:
+    - ``hwave`` stores either arccos(x) or arccos(x)/2 sampled uniformly for x in [0, 1].
+    - Uniform spacing, nearest-neighbor addressing (FPGA-style integer index rounding).
+    - No interpolation; quantization error is intentional for distortion analysis.
+
+    Method:
+    For x >= 0:  arccos(x)  = LUT(x)
+    For x < 0:   arccos(x)  = π - arccos(|x|)
+    """
+    n = hwave.size
+    if n == 0:
+        return np.array([], dtype=hwave.dtype)
+
+    n_points = n * 2
+    x = np.linspace(-1.0, 1.0, n_points, dtype=hwave.dtype)
+    absx = np.abs(x)
+
+    # Nearest-neighbor index mapping into [0,1] domain.
+    u = absx * (n - 1)
+    idx = np.rint(u).astype(int, copy=False)
+    vals = hwave[idx]
+
+    # Reflect for negative x using arccos(-x) = π - arccos(x).
+    neg_mask = x < 0
+    if np.any(neg_mask):
+        vals[neg_mask] = np.pi - vals[neg_mask]
+
+    return vals
+
+
 def reconstruct_arccos_qwave(qwave: np.ndarray[np.number]) -> np.ndarray[np.number] | np.number:
-    """
-    Reconstruct arccos(x) using the identity:
-    arccos(x) = 2 * f(√((1+x)/2))
-    where f is the quarter table LUT for arccos over t in [0, 1/√2].
+    """Reconstruct arccos(x) for x∈[-1,1] from a quarter-wave LUT storing
+    arccos(t) for t∈[0,1/√2] (uniform). Identity used (mirrors arcsin structure):
 
-    For t > 1/√2, use the complement identity to map back into the stored domain:
-        arccos(t) = π/2 - arccos( sqrt(1 - t^2) )
-    """
-    n_points = qwave.size * 4
-    x = np.linspace(-1.0, 1.0, n_points)
+        Let a = sqrt((1 + x)/2) ∈ [0,1]. Define b = sqrt((1 - a)/2).
+        Then arccos(x) = 2 * arccos(b) with b ∈ [0,1/√2].
 
-    # t(x) = sqrt((1 + x)/2) ∈ [0, 1]
-    t = np.sqrt(np.clip(1.0 + x, 0.0, 2.0) * 0.5)
+    Derivation: set θ = arccos(x). Half-angle gives cos(θ/2)=sqrt((1+x)/2)=a.
+    Also cos(θ) = 1 - 2 sin^2(θ/2) => sin(θ/2)=sqrt((1 - cos(θ))/2)=sqrt((1 - x)/2).
+    We need expression producing argument constrained to [0,1/√2]; using nested
+    half-angle again on cos(θ/2)=a: cos(θ/4)=sqrt((1 + a)/2), sin(θ/4)=sqrt((1 - a)/2).
+    Choosing b = sin(θ/4) ensures b ∈ [0, 1/√2] and θ = 4 * arcsin(b) = 2 * (2 * arcsin(b)).
+    Since table stores arccos, we use arcsin relation arcsin(b) = π/2 - arccos(b):
+        θ = 4*(π/2 - arccos(b)) = 2π - 4*arccos(b).
+    For numerical stability and consistency we implement θ = 2π - 4*arccos(b).
+    """
+    n = qwave.size
+    if n == 0:
+        return np.array([], dtype=qwave.dtype)
+
+    n_points = n * 4
+    x = np.linspace(-1.0, 1.0, n_points, dtype=qwave.dtype)
+
+    a = np.sqrt(np.clip(1.0 + x, 0.0, 2.0) * 0.5)  # in [0,1]
+    b = np.sqrt((1.0 - a) * 0.5)  # in [0,1/√2]
 
     inv_sqrt2 = 1.0 / np.sqrt(2.0)
-    lut_domain = np.linspace(0.0, inv_sqrt2, qwave.size)
+    lut_domain = np.linspace(0.0, inv_sqrt2, n)
 
-    y_half = np.empty_like(t)
-    mask_direct = t <= inv_sqrt2
-    mask_compl = ~mask_direct
+    vals_half = np.interp(b, lut_domain, qwave)
 
-    y_half[mask_direct] = np.interp(t[mask_direct], lut_domain, qwave)
-    if np.any(mask_compl):
-        t_comp = np.sqrt(np.maximum(0.0, 1.0 - t[mask_compl]**2))
-        y_comp = np.interp(t_comp, lut_domain, qwave)
-        y_half[mask_compl] = (np.pi / 2.0) - y_comp
-
-    return 2.0 * y_half
+    # θ = 2π - 4 * arccos(b)
+    vals = 2.0 * np.pi - 4.0 * vals_half
+    return vals
 
 
 def get_reconstructed_from_lut(table: np.ndarray[np.floating | np.integer],
                                table_mode: TABLE_MODE, signal_name: str) -> np.ndarray[np.floating] | np.float32:
     table_mode = table_mode.value
 
+    if table.size <= 1:
+        return np.float32(0)
+
     if table_mode == 0 or table_mode == 3:
         return table
 
     if table_mode == 1:
-        raise NotImplementedError('No reconstruction method exists for medium mode yet.')
+        hwave = table
 
-    if table_mode == 2:
+        if signal_name == 'arccos':
+            return reconstruct_arccos_hwave(hwave=hwave)
+
+    elif table_mode == 2:
         qwave = table
-
-        if qwave.size <= 1:
-            return np.float32(0)
 
         if signal_name == 'sin':
             return reconstruct_sin_qwave(qwave=qwave)
@@ -122,4 +164,4 @@ def get_reconstructed_from_lut(table: np.ndarray[np.floating | np.integer],
         if signal_name == 'arccos':
             return reconstruct_arccos_qwave(qwave=qwave)
 
-        raise NotImplementedError(f'No reconstruction method exists for {signal_name} yet')
+    raise NotImplementedError(f'No reconstruction method exists for {signal_name} yet in table mode {table_mode}')

--- a/Src/Scripts/generate_trig_luts.py
+++ b/Src/Scripts/generate_trig_luts.py
@@ -204,6 +204,10 @@ def main() -> None:
                         help='Creates an acos (arccos) LUT. Not turned on by default.'
                         )
 
+    parser.add_argument('--adaptive-arc', action='store_true', default=False,
+                        help='Use derivative-weighted adaptive sampling for arcsin/arccos (MED mode) to reduce NN/distortion error'
+                        )
+
     parser.add_argument('--atan', action='store_true', default=False,
                         help='Creates an atan (arctan) LUT'
                         )
@@ -863,34 +867,38 @@ def generate_asin_acos_domain(xs: Mapping[str, np.ndarray[np.floating]], trig_pa
         if not trig_parser.args['no_quantize']:
             sz = quantize(sz, dtype=trig_parser.bw_type_int)
 
+        """
+        Per. https://github.com/topologicalhurt/Thesis/discussions/46
+        The index recovery method is non-linearly distributed over the LUT in HIGH & MEDIUM modes.
+        If the args are linearly spaced, it could introduce quantization error (I.e. major discontinuities)
+        due to the relative sparsity or density of the lookup method.
+        """
         match table_mode:
             case TRIG_OPT_MODE.MAX:
                 raise NotImplementedError(f'Max mode not yet supported for {k.name}')
             case TRIG_OPT_MODE.HIGH:
-                """
-                Per. https://github.com/topologicalhurt/Thesis/discussions/46
-                The index recovery method is non-linearly distributed over the LUT.
-                If the args are linearly spaced, it will introduce quantization error (I.e. major discontinuities)
-                due to the relative sparsity or density of the lookup method.
-                """
-                inv_sqrt2 = 1.0 / np.sqrt(2.0)
-                qwave_domain = np.linspace(0.0, inv_sqrt2, sz, dtype=trig_parser.args['bw'])
-                domain_fn = lambda: np.linspace(-1.0, 1.0, sz*4, dtype=trig_parser.args['bw']) # noqa: E731
+                if trig_parser.args.get('adaptive_arc', False):
+                    LOGGER.warning('adaptive_arc ignored for HIGH mode arcsin/arccos (quarter-wave) to preserve uniform domain')
 
-                xs[k] = (qwave_domain, domain_fn)
+                if k == TRIG_DEFS.ACOS:
+                    domain = np.linspace(0.0, 1.0/np.sqrt(2.0), sz, dtype=trig_parser.args['bw'])
+                elif k == TRIG_DEFS.ASIN:
+                    domain = np.linspace(0.0, 1.0/np.sqrt(2.0), sz, dtype=trig_parser.args['bw'])
+                else:
+                    raise assert_never(f'Unexpected function {k} in arc_sinusoids HIGH mode')
 
-                continue
+                domain_fn = lambda: np.linspace(-1, 1, sz*4, dtype=trig_parser.args['bw']) # noqa: E731
             case TRIG_OPT_MODE.MED:
-                raise NotImplementedError(f'Half table not yet supported for {k.name}')
+                hwave_domain = np.linspace(0, 1, sz, dtype=trig_parser.args['bw'])
+                domain = hwave_domain
+                domain_fn = lambda: np.linspace(-1, 1, sz*2, dtype=trig_parser.args['bw'])      # noqa: E731
             case TRIG_OPT_MODE.LOW:
-                start = -1
-                stop = 1
+                domain = np.linspace(-1, 1, sz, dtype=trig_parser.args['bw'])
+                domain_fn = lambda: np.linspace(-1, 1, sz, dtype=trig_parser.args['bw'])        # noqa: E731
             case _:
                 assert_never(table_mode)
 
-        xs[k] = (np.linspace(start, stop, sz, dtype=trig_parser.args['bw']),
-                 functools.partial(np.linspace, start, stop=scale_factor*stop, sz=scale_factor*sz, dtype=trig_parser.args['bw'])
-                )
+        xs[k] = (domain, domain_fn)
 
 
 def generate_atan_domain(xs: Mapping[str, np.ndarray[np.floating]], trig_parser: _TrigArgParser) -> None:
@@ -1076,7 +1084,8 @@ def _generate_luts(trig_parser: _TrigArgParser, phis: Mapping[str, np.ndarray], 
                                                                          axis=test_axis,
                                                                          oversample_factor=trig_parser.args['osf']
                                                                          )
-                thd_acc_report = acc_metrics.assess_thd()
+
+                thd_acc_report = acc_metrics.select_distortion_metric()
 
                 acc_report = LUT_ACC_REPORT(f_name=lut.fn.__name__,
                                             quant_acc_report=quant_acc_report,
@@ -1117,6 +1126,24 @@ def _calculate_scale_factor(table_mode: TRIG_OPT_MODE, table_prec: TRIG_PRECISIO
     Calculate the 'scale' factor for a LUT I.e. the ratio between optimisation:precision
     """
     return max(table_mode.value * (TRIG_PRECISION.HIGHP.value - table_prec.value), 1)
+
+
+def _adaptive_arc_domain(sz: int, trig_parser: _TrigArgParser, hr_mult: int = 16, eps: float = 1e-6) -> np.ndarray[np.floating]:
+    """Derivative-weighted adaptive sampling for arcsin/arccos.
+
+    Places nodes so |f'(x)| * local_step ~ constant with f'(x)=±1/sqrt(1-x^2).
+    Returns sz points in [-1,1]. First/last forced to exact endpoints.
+    """
+    bw = trig_parser.args['bw']
+    x_hr = np.linspace(-1.0, 1.0, sz * hr_mult, dtype=bw)
+    denom = np.sqrt(np.clip(1.0 - x_hr * x_hr, 1e-18, None))
+    w = 1.0 / denom + np.float64(eps)
+    cdf = np.cumsum(w)
+    cdf /= cdf[-1]
+    p = np.linspace(0.0, 1.0, sz, dtype=bw)
+    x_nodes = np.interp(p, cdf, x_hr).astype(bw)
+    x_nodes[0], x_nodes[-1] = -1.0, 1.0
+    return x_nodes
 
 
 def _get_fn_from_optmode(m: TRIG_DEFS, trig_parser: _TrigArgParser) -> Callable[[np.ndarray], np.ndarray[np.floating]]:


### PR DESCRIPTION
…xpanded Distortion Suite, Type Tightening

Summary:
Comprehensive update focusing on arccos/arcsin LUT generation domains, reconstruction identities, adaptive sampling controls, expanded distortion/accuracy metrics, and stricter NumPy typing across dataclasses and metrics. Aligns HIGH mode inverse trig quarter-wave domain with shared [0, 1/√2] strategy, introduces half-wave reconstruction for arccos, adds multiple alternative distortion metrics (k-cut, Chebyshev residual, residual RMS), and integrates selection logic for context-aware metric evaluation. Improves lazy norm caching and report verbosity (test_type). All changes staged span dataclass structures, signal metrics, LUT generation script, and reconstructor.

[*] Feat / Reconstruction:
- Added reconstruct_arccos_hwave (half-wave) using nearest-neighbor indexing with even symmetry (π - f(|x|)).
- Replaced previous quarter-wave arccos path with nested half-angle identity: θ = 2π - 4*arccos(b) where b = sqrt((1 - sqrt((1 + x)/2))/2) ensuring argument stays within [0,1/√2].
- Ensured arcsin quarter-wave reconstruction unchanged but clarified domain usage and interpolation path.

[*] Feat / Distortion Metrics:
- Implemented k-cut distortion metric (dct_kcut_distortion) for finite/non-periodic or fft periodic signals.
- Implemented Chebyshev-based model distortion (cheb_model_distortion) with residual/model energy ratio.
- Implemented residual RMS ratio metric plus reporting wrapper (residual_rms_report).
- Added unified select_distortion_metric dispatcher choosing THD for periodic trig vs Chebyshev model for inverse trig (asin, acos, atan).

[*] Refactor / Signal Metrics:
- THD assessment: split periodic (FFT) and non-periodic (DCT-II) paths; added polynomial detrend for inverse trig to suppress low-order curvature before harmonic/residual assessment.
- Removed unused band_power free function; inlined logic via staticmethod band_power in class (note: currently unused after redesign, retained for potential future fractional-bin metrics).
- Added private helpers: _poly_detrend, _cheb_detrend, _dist_scalar_db.
- Normalized returns to supply LUT_THD_ACC_REPORT with explicit test_type tags (THD, K_CUT_DIST, CHEB_MODEL, RESIDUAL_RMS).

[*] Refactor / Dataclasses & Typing:
- Tightened ndarray element annotations to np.float64 for float pathways (signal, domains, LUTs) for consistency & clarity.
- Extended SignalStatistic.__slots__ with cached norms (_signal_norm, _unbiased_signal_norm) reducing recomputation.
- Added properties: signal, signal_name, signal_type, signal_norm, unbiased_signal_norm.
- Added test_type to LUT_THD_ACC_REPORT plus richer __str__ formatting per metric type.
- Updated QFormat typing (get_converted/get_float_representation) to use np.float64.

[*] Feat / LUT Generation (generate_trig_luts.py):
- Added --adaptive-arc flag (derivative-weighted adaptive sampling) for MED mode inverse trig (half-wave) only; explicitly ignored (with warning) for HIGH quarter-wave to preserve uniform domain assumptions required by reconstruction identities.
- Changed HIGH mode arccos domain from [0,1] to [0,1/√2]; arcsin already uses [0,1/√2]; unifies storage enabling shared sqrt-based nested half-angle reconstruction.
- Reintroduced quarter-wave domain handling block with explicit conditional for ACOS / ASIN.
- Added adaptive domain helper _adaptive_arc_domain (derivative-weighted via |f'| = 1/sqrt(1-x^2)).
- Switched THD call in LUT generation to select_distortion_metric for context-aware metric choice.

[*] Behavioral Adjustments:
- Quarter-wave adaptive sampling disabled to avoid domain mismatch with identity-based inverse trig reconstruction (logged warning when attempted).
- Non-periodic distortion metrics apply polynomial detrending (order 3) before DCT to isolate higher-order components.
- Saturation of domain arguments removed for new arccos quarter-wave path; identity ensures inner argument always within stored range without clamping.

[*] Removal / Clean-up:
- Removed legacy arccos quarter-wave reconstruction logic using direct sqrt((1+x)/2) + complement fallback; replaced with nested approach.
- Removed commented import of find_nearest (not used in current quarter-wave reconstruction; retained nearest neighbor only for half-wave).

[*] Reporting Enhancements:
- test_type field propagated enabling downstream differentiation of metric context (THD vs Chebyshev vs K-cut vs Residual RMS).
- Distortion scalar consistently returned as np.float64; dB values robust to zero-energy cases via tiny floor.

[*] Performance / Memory:
- Added caching of raw and unbiased signal norms reducing repeated np.sum calls in large signal scenarios.
- Employed np.float64 throughout to avoid inadvertent up/down casting during spectral operations.

[*] Safety / Edge Cases:
- Guard conditions for small signals (<4 samples) in all distortion metrics returning defined degenerate reports.
- Handled empty LUT tables early in reconstruction routines returning empty arrays.
- Ensured polynomial order does not exceed n-1 in detrend and Chebyshev fitting.

[*] Misc:
- Updated NotImplementedError messages to include table mode context for clarity.
- Inline comments / docstrings expanded for reconstruction identities (derivations and domain constraints).

Potential Follow-ups:
- Add unit tests validating max absolute reconstruction error for asin/acos across resolutions and adaptive vs uniform domains.
- Integrate fractional-bin band-power leakage mitigation for near-periodic finite intervals.
- Explore dynamic selection among distortion metrics based on monotonicity detection or residual spectral flatness.
- Add option to serialize domain metadata when using adaptive quarter-wave (if re-enabled) to permit accurate reconstruction.
- Provide CLI toggles to expose alternative distortion metrics in reports simultaneously.